### PR TITLE
Allow reconfiguration during runtime with getch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hlua 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ldap3 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,6 +82,7 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -300,6 +302,15 @@ dependencies = [
 name = "gcc"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hlua"
@@ -1066,6 +1077,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1451,7 @@ dependencies = [
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum getch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5d74884542f30bafa33aa6615b63d6f430f57546e60e3bd59895d5459d776ab"
 "checksum hlua 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ed9db71fff2e55b83d24bbbdd9ad13f0d1ff79bc265f544370f39ee0825d54e4"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
@@ -1510,6 +1538,8 @@ dependencies = [
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+"checksum termios 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70226acdf12d182df757d9fb07c0257a1558ec48c8059f607d6b38145ce4e2fa"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ time = "0.1.35"
 atty = "0.2"
 rand = "0.4"
 getch = "0.2"
-termios = "0.3"
 
 reqwest = "0.8"
 mysql = "12.2.0"
 ldap3 = "0.5"
+
+[target."cfg(unix)".dependencies]
+termios = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ error-chain = "0.11"
 time = "0.1.35"
 atty = "0.2"
 rand = "0.4"
+getch = "0.2"
+termios = "0.3"
 
 reqwest = "0.8"
 mysql = "12.2.0"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ single service and provide a `verify(user, password)` function that returns
 either true or false. Concurrency, progress indication and reporting is
 magically provided by the badtouch runtime.
 
+[![asciicast](https://asciinema.org/a/Ke5rHVsz5sJePNUK1k0ASAvuZ.png)](https://asciinema.org/a/Ke5rHVsz5sJePNUK1k0ASAvuZ)
+
 ## Reference
 - [execve](#execve)
 - [http_basic_auth](#http_basic_auth)

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,0 +1,52 @@
+// use getch;
+use getch::Getch;
+
+#[cfg(not(windows))]
+use termios::{self, tcsetattr, ICANON, ECHO};
+
+pub struct Keyboard {
+    getch: Getch,
+}
+
+impl Keyboard {
+    pub fn new() -> Keyboard {
+        let getch = Getch::new();
+
+        Keyboard {
+            getch,
+        }
+    }
+
+    pub fn get(&self) -> Key {
+        loop {
+            let key = self.getch.getch();
+            // println!("{:?}", key);
+            match key {
+                Ok(112) => return Key::P,
+                Ok(114) => return Key::R,
+                Ok(43)  => return Key::Plus,
+                Ok(45)  => return Key::Minus,
+                _ => (),
+            }
+        }
+    }
+
+    // since the getch thread is orphaned, we have to cleanup manually
+    pub fn reset() {
+        #[cfg(not(windows))]
+        {
+            if let Ok(mut termios) = termios::Termios::from_fd(0) {
+                termios.c_lflag |= ICANON|ECHO;
+                tcsetattr(0,termios::TCSADRAIN, &termios).unwrap_or(());
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Key {
+    P,
+    R,
+    Plus,
+    Minus,
+}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -26,6 +26,7 @@ impl Keyboard {
                 Ok(114) => return Key::R,
                 Ok(43)  => return Key::Plus,
                 Ok(45)  => return Key::Minus,
+                Ok(104) => return Key::H,
                 _ => (),
             }
         }
@@ -45,6 +46,7 @@ impl Keyboard {
 
 #[derive(Debug)]
 pub enum Key {
+    H,
     P,
     R,
     Plus,

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,10 +194,12 @@ fn run() -> Result<()> {
                         pool.resume();
                     },
                     Key::Plus => {
-                        println!("plus!");
+                        let num = pool.incr();
+                        pb.writeln(format!("{} {}", "[*]".bold(), format!("increased to {} threads", num).dimmed()));
                     },
                     Key::Minus => {
-                        println!("minus!");
+                        let num = pool.decr();
+                        pb.writeln(format!("{} {}", "[*]".bold(), format!("decreased to {} threads", num).dimmed()));
                     },
                 }
                 pb.tick();

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,10 +181,20 @@ fn run() -> Result<()> {
         match pool.recv() {
             Msg::Key(key) => {
                 match key {
-                    Key::P => println!("pause!"),
-                    Key::R => println!("resume!"),
-                    Key::Plus => println!("plus!"),
-                    Key::Minus => println!("minu!"),
+                    Key::P => {
+                        pb.writeln(format!("{} {}", "[*]".bold(), "pausing threads".dimmed()));
+                        pool.pause();
+                    },
+                    Key::R => {
+                        pb.writeln(format!("{} {}", "[*]".bold(), "resuming threads".dimmed()));
+                        pool.resume();
+                    },
+                    Key::Plus => {
+                        println!("plus!");
+                    },
+                    Key::Minus => {
+                        println!("minus!");
+                    },
                 }
                 pb.tick();
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,10 @@ fn run() -> Result<()> {
         match pool.recv() {
             Msg::Key(key) => {
                 match key {
+                    Key::H => {
+                        pb.writeln(format!("{} {}", "[+]".bold(),
+                            "[h] help, [p] pause, [r] resume, [+] increase threads, [-] decrease threads".dimmed()));
+                    },
                     Key::P => {
                         pb.writeln(format!("{} {}", "[*]".bold(), "pausing threads".dimmed()));
                         pool.pause();

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ mod scheduler;
 use pb::ProgressBar;
 use error_chain::ChainedError;
 use colored::*;
-use scheduler::{Scheduler, Attempt};
+use scheduler::{Scheduler, Attempt, Msg};
 use keyboard::{Keyboard, Key};
 use std::thread;
 use std::fs::{self, File};
@@ -162,15 +162,12 @@ fn run() -> Result<()> {
         args::SubCommand::Creds(creds) => setup_credential_confirmation(&mut pool, creds)?,
     };
 
-    thread::spawn(|| {
+    let tx = pool.tx();
+    thread::spawn(move || {
         let kb = Keyboard::new();
         loop {
-            match kb.get() {
-                Key::P => println!("pause!"),
-                Key::R => println!("resume!"),
-                Key::Plus => println!("plus!"),
-                Key::Minus => println!("minu!"),
-            }
+            let key = kb.get();
+            tx.send(Msg::Key(key)).expect("failed to send key");
         }
     });
 
@@ -181,33 +178,44 @@ fn run() -> Result<()> {
     let mut retries = 0;
     let mut expired = 0;
     while pool.has_work() {
-        let (mut attempt, result) = pool.recv();
-
-        match result {
-            Ok(is_valid) => {
-                if is_valid {
-                    pb.writeln(format!("{} {}({}) => {:?}:{:?}", "[+]".bold(), "valid".green(),
-                        attempt.script.descr().yellow(), attempt.user, attempt.password));
-                    valid += 1;
+        match pool.recv() {
+            Msg::Key(key) => {
+                match key {
+                    Key::P => println!("pause!"),
+                    Key::R => println!("resume!"),
+                    Key::Plus => println!("plus!"),
+                    Key::Minus => println!("minu!"),
                 }
-                pb.inc();
+                pb.tick();
             },
-            Err(err) => {
-                pb.writeln(format!("{} {}({}, {}): {:?}", "[!]".bold(), "error".red(), attempt.script.descr().yellow(), format!("{:?}:{:?}", attempt.user, attempt.password).dimmed(), err));
+            Msg::Attempt(mut attempt, result) => {
+                match result {
+                    Ok(is_valid) => {
+                        if is_valid {
+                            pb.writeln(format!("{} {}({}) => {:?}:{:?}", "[+]".bold(), "valid".green(),
+                                attempt.script.descr().yellow(), attempt.user, attempt.password));
+                            valid += 1;
+                        }
+                        pb.inc();
+                    },
+                    Err(err) => {
+                        pb.writeln(format!("{} {}({}, {}): {:?}", "[!]".bold(), "error".red(), attempt.script.descr().yellow(), format!("{:?}:{:?}", attempt.user, attempt.password).dimmed(), err));
 
-                if attempt.ttl > 0 {
-                    // we have retries left
-                    retries += 1;
-                    attempt.ttl -= 1;
-                    pool.run(attempt);
-                    pb.tick();
-                } else {
-                    // giving up
-                    expired += 1;
-                    pb.inc();
-                }
-            }
-        };
+                        if attempt.ttl > 0 {
+                            // we have retries left
+                            retries += 1;
+                            attempt.ttl -= 1;
+                            pool.run(attempt);
+                            pb.tick();
+                        } else {
+                            // giving up
+                            expired += 1;
+                            pb.inc();
+                        }
+                    }
+                };
+            },
+        }
     }
 
     let elapsed = start.elapsed();

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ fn run() -> Result<()> {
     });
 
     let mut pb = ProgressBar::new(attempts as u64);
+    pb.print_help();
     pb.tick();
 
     let mut valid = 0;
@@ -181,10 +182,7 @@ fn run() -> Result<()> {
         match pool.recv() {
             Msg::Key(key) => {
                 match key {
-                    Key::H => {
-                        pb.writeln(format!("{} {}", "[+]".bold(),
-                            "[h] help, [p] pause, [r] resume, [+] increase threads, [-] decrease threads".dimmed()));
-                    },
+                    Key::H => pb.print_help(),
                     Key::P => {
                         pb.writeln(format!("{} {}", "[*]".bold(), "pausing threads".dimmed()));
                         pool.pause();

--- a/src/pb.rs
+++ b/src/pb.rs
@@ -11,6 +11,7 @@
 
 use pbr;
 use atty;
+use colored::Colorize;
 use std::fmt::Display;
 use std::io::prelude::*;
 use std::io::{self, Stdout};
@@ -58,6 +59,12 @@ impl ProgressBar {
         }
 
         self.pb.tick()
+    }
+
+    #[inline]
+    pub fn print_help(&mut self) {
+        self.writeln(format!("{} {}", "[+]".bold(),
+            "[h] help, [p] pause, [r] resume, [+] increase threads, [-] decrease threads".dimmed()));
     }
 
     #[inline]


### PR DESCRIPTION
- [p] to pause workers, without interrupting active attempts
- [r] to resume workers
- [+] to increase the number of threads
- [-] to decrease the number of threads, without interrupting active attempts

Related to #3