### PR TITLE
Support testing directly on databases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ version = "0.4.0"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bcrypt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.195 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -120,6 +121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blowfish 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +154,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -979,6 +1010,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
@@ -1926,10 +1962,13 @@ dependencies = [
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
+"checksum bcrypt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a1512813db09170b44a00870b58421876d797b77b085c5205a24db90905f758"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum block-cipher-trait 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6136d803280ae3532efa36114335255ea94f3d75d735ddedd66b0d7cd30bad3"
+"checksum blowfish 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95ede07672d9f4144c578439aa352604ec5c67a80c940fe8d382ddbeeeb3c6d8"
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
@@ -2024,6 +2063,7 @@ dependencies = [
 "checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)" = "0bbd90640b148b46305c1691eed6039b5c8509bed16991e3562a01eeb76902a3"
 "checksum pbr 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e048e3afebb6c454bb1c5d0fe73fda54698b4715d78ed8e7302447c37736d23a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twox-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ hyper = "0.11.22"
 mysql = "12.2.0"
 ldap3 = "0.6"
 kuchiki = "0.7"
+twox-hash = "1.1"
 
 clippy = { version = "*", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ sha3 = "0.7"
 digest = "0.7"
 hmac = "0.6"
 base64 = "0.9"
+bcrypt = "0.2"
 
 reqwest = "0.8"
 hyper = "0.11.22"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ magically provided by the badtouch runtime.
 ## Reference
 - [base64_decode](#base64_decode)
 - [base64_encode](#base64_encode)
+- [clear_err](#clear_err)
 - [execve](#execve)
 - [hex](#hex)
 - [hmac_md5](#hmac_md5)
@@ -47,6 +48,7 @@ magically provided by the badtouch runtime.
 - [ldap_search_bind](#ldap_search_bind)
 - [md5](#md5)
 - [mysql_connect](#mysql_connect)
+- [mysql_query](#mysql_query)
 - [print](#print)
 - [rand](#rand)
 - [randombytes](#randombytes)
@@ -70,6 +72,17 @@ base64_decode("ww==")
 Encode a binary array with base64.
 ```lua
 base64_encode("\x00\xff")
+```
+
+### clear_err
+Clear all recorded errors to prevent a requeue.
+```lua
+if last_err() then
+    clear_err()
+    return false
+else
+    return true
+end
 ```
 
 ### execve
@@ -261,9 +274,18 @@ hex(md5("\x00\xff"))
 
 ### mysql_connect
 Connect to a mysql database and try to authenticate with the provided
-credentials. Returns `true` on success.
+credentials. Returns a mysql connection on success.
 ```lua
-mysql_connect("127.0.0.1", 3306, user, password)
+sock = mysql_connect("127.0.0.1", 3306, user, password)
+```
+
+### mysql_query
+Run a query on a mysql connection. The 3rd parameter is for prepared
+statements.
+```lua
+rows = mysql_query(sock, 'SELECT VERSION(), :foo as foo', {
+    foo='magic'
+})
 ```
 
 ### print

--- a/docs/badtouch.1
+++ b/docs/badtouch.1
@@ -73,6 +73,20 @@ Encode a binary array with base64.
 .fi
 .RE
 
+.SS clear_err
+.LP
+Clear all recorded errors to prevent a requeue.
+.RS
+.nf
+\fBif last_err() then
+    clear_err()
+    return false
+else
+    return true
+end\fP
+.fi
+.RE
+
 .SS execve
 .LP
 Execute an external program. Returns the exit code.
@@ -327,10 +341,22 @@ Hash a byte array with md5 and return the results as bytes.
 .SS mysql_connect
 .LP
 Connect to a mysql database and try to authenticate with the provided
-credentials. Returns \fBtrue\fP on success.
+credentials. Returns a mysql connection on success.
 .RS
 .nf
-\fBmysql_connect("127.0.0.1", 3306, user, password)\fP
+\fBsock = mysql_connect("127.0.0.1", 3306, user, password)\fP
+.fi
+.RE
+
+.SS mysql_query
+.LP
+Run a query on a mysql connection. The 3rd parameter is for prepared
+statements.
+.RS
+.nf
+\fBrows = mysql_query(sock, 'SELECT VERSION(), :foo as foo', {
+    foo='magic'
+})\fP
 .fi
 .RE
 

--- a/scripts/mysql-connect.lua
+++ b/scripts/mysql-connect.lua
@@ -1,0 +1,12 @@
+descr = "local mysql"
+
+function verify(user, password)
+    mysql_connect("127.0.0.1", 3306, user, password)
+
+    if last_err() then
+        clear_err()
+        return false
+    else
+        return true
+    end
+end

--- a/scripts/mysql-query.lua
+++ b/scripts/mysql-query.lua
@@ -1,0 +1,18 @@
+descr = "local mysql query"
+
+function verify(user, password)
+    sock = mysql_connect("127.0.0.1", 3306, "root", "my-secret-pw")
+    if last_err() then return end
+
+    rows = mysql_query(sock, 'SELECT VERSION(), :foo as foo', {
+        foo='magic'
+    })
+    if last_err() then return end
+
+    if rows[1] then
+        print(rows[1])
+        return true
+    else
+        return false
+    end
+end

--- a/scripts/mysql.lua
+++ b/scripts/mysql.lua
@@ -1,5 +1,0 @@
-descr = "local mysql"
-
-function verify(user, password)
-    return mysql_connect("127.0.0.1", 3306, user, password)
-end

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -111,6 +111,8 @@ impl Script {
 
         runtime::base64_decode(&mut lua, state.clone());
         runtime::base64_encode(&mut lua, state.clone());
+        runtime::bcrypt(&mut lua, state.clone());
+        runtime::bcrypt_verify(&mut lua, state.clone());
         runtime::execve(&mut lua, state.clone());
         runtime::hex(&mut lua, state.clone());
         runtime::hmac_md5(&mut lua, state.clone());
@@ -468,6 +470,20 @@ mod tests {
         "#.as_bytes(), empty_config()).unwrap();
 
         let result = script.run_once("x", "x").expect("test script failed");
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_bcrypt_verify() {
+        let script = Script::load_from(r#"
+        descr = "bcrypt_verify"
+
+        function verify(user, password)
+            return bcrypt_verify(password, "$2a$12$ByUlHCHx3rxMsdQONpuFbulQqut6GQ/84I5EAUkCqTTI07JA7wUju")
+        end
+        "#.as_bytes(), empty_config()).unwrap();
+
+        let result = script.run_once("x", "hunter2").expect("test script failed");
         assert!(result);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,0 +1,1 @@
+pub mod mysql;

--- a/src/db/mysql.rs
+++ b/src/db/mysql.rs
@@ -1,0 +1,72 @@
+use hlua::{AnyHashableLuaValue, AnyLuaValue};
+use mysql;
+
+use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+use twox_hash::XxHash;
+use structs::LuaMap;
+
+
+impl From<mysql::Params> for LuaMap {
+    fn from(params: mysql::Params) -> LuaMap {
+        match params {
+            mysql::Params::Empty => LuaMap::new(),
+            mysql::Params::Named(map) => {
+                map.into_iter()
+                    .map(|(k, v)| (AnyHashableLuaValue::LuaString(k), mysql_value_to_lua(v)))
+                    .collect::<HashMap<AnyHashableLuaValue, AnyLuaValue>>()
+                    .into()
+            },
+            mysql::Params::Positional(_) => unimplemented!(),
+        }
+    }
+}
+
+impl Into<mysql::Params> for LuaMap {
+    fn into(self) -> mysql::Params {
+        if self.is_empty() {
+            mysql::Params::Empty
+        } else {
+            let mut params: HashMap<String, mysql::Value, BuildHasherDefault<XxHash>> = HashMap::default();
+
+            for (k, v) in self {
+                if let AnyHashableLuaValue::LuaString(k) = k {
+                    params.insert(k, lua_to_mysql_value(v));
+                } else {
+                    panic!("unsupported keys in map");
+                }
+            }
+
+            mysql::Params::Named(params)
+        }
+    }
+}
+
+fn lua_to_mysql_value(value: AnyLuaValue) -> mysql::Value {
+    match value {
+        AnyLuaValue::LuaString(x) => mysql::Value::Bytes(x.into_bytes()),
+        AnyLuaValue::LuaAnyString(x) => mysql::Value::Bytes(x.0),
+        AnyLuaValue::LuaNumber(v) => if v % 1f64 == 0f64 {
+            mysql::Value::Int(v as i64)
+        } else {
+            mysql::Value::Float(v)
+        },
+        AnyLuaValue::LuaBoolean(x) => mysql::Value::Int(if x { 1 } else { 0 }),
+        AnyLuaValue::LuaArray(_x) => unimplemented!(),
+        AnyLuaValue::LuaNil => mysql::Value::NULL,
+        AnyLuaValue::LuaOther => unimplemented!(),
+    }
+}
+
+pub fn mysql_value_to_lua(value: mysql::Value) -> AnyLuaValue {
+    use mysql::Value::*;
+    match value {
+        NULL => AnyLuaValue::LuaNil,
+        Bytes(bytes) => AnyLuaValue::LuaString(String::from_utf8(bytes).unwrap()),
+        Int(i) => AnyLuaValue::LuaNumber(i as f64),
+        UInt(i) => AnyLuaValue::LuaNumber(i as f64),
+        Float(i) => AnyLuaValue::LuaNumber(i),
+        Date(_, _, _, _, _, _, _) => unimplemented!(),
+        Time(_, _, _, _, _, _) => unimplemented!(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate sha3;
 extern crate digest;
 extern crate hmac;
 extern crate base64;
+extern crate bcrypt;
 
 #[cfg(not(windows))]
 extern crate termios;
@@ -61,6 +62,7 @@ pub mod errors {
     use base64;
     use toml;
     use nix;
+    use bcrypt;
 
     error_chain! {
         foreign_links {
@@ -74,6 +76,7 @@ pub mod errors {
             Base64Decode(base64::DecodeError);
             Toml(toml::de::Error);
             Nix(nix::Error);
+            Bcrypt(bcrypt::BcryptError);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,12 @@ extern crate termios;
 extern crate reqwest;
 extern crate mysql;
 extern crate ldap3;
+extern crate twox_hash;
 
 pub mod args;
 pub mod config;
 pub mod ctx;
+pub mod db;
 pub mod fsck;
 pub mod html;
 pub mod http;
@@ -63,6 +65,7 @@ pub mod errors {
     use toml;
     use nix;
     use bcrypt;
+    use mysql;
 
     error_chain! {
         foreign_links {
@@ -77,6 +80,7 @@ pub mod errors {
             Toml(toml::de::Error);
             Nix(nix::Error);
             Bcrypt(bcrypt::BcryptError);
+            Mysql(mysql::Error);
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -51,53 +51,38 @@ fn byte_array(bytes: AnyLuaValue) -> Result<Vec<u8>> {
     }
 }
 
-pub fn lua_bytes(bytes: &[u8]) -> AnyLuaValue {
+fn lua_bytes(bytes: &[u8]) -> AnyLuaValue {
     let bytes = AnyLuaString(bytes.to_vec());
     AnyLuaValue::LuaAnyString(bytes)
 }
 
-
 pub fn base64_decode(lua: &mut hlua::Lua, state: State) {
     lua.set("base64_decode", hlua::function1(move |bytes: String| -> Result<AnyLuaValue> {
-        let bytes = match base64::decode(&bytes) {
-            Ok(bytes) => bytes,
-            Err(err) => return Err(state.set_error(err.into())),
-        };
-
-        Ok(lua_bytes(&bytes))
+        base64::decode(&bytes)
+            .map_err(|err| state.set_error(err.into()))
+            .map(|bytes| lua_bytes(&bytes))
     }))
 }
 
 pub fn base64_encode(lua: &mut hlua::Lua, state: State) {
     lua.set("base64_encode", hlua::function1(move |bytes: AnyLuaValue| -> Result<String> {
-        let bytes = match byte_array(bytes) {
-            Ok(bytes) => bytes,
-            Err(err) => return Err(state.set_error(err)),
-        };
-
-        Ok(base64::encode(&bytes))
+        byte_array(bytes)
+            .map_err(|err| state.set_error(err))
+            .map(|bytes| base64::encode(&bytes))
     }))
 }
 
 pub fn bcrypt(lua: &mut hlua::Lua, state: State) {
     lua.set("bcrypt", hlua::function2(move |password: String, cost: u32| -> Result<String> {
-        let result = match bcrypt::hash(&password, cost) {
-            Ok(result) => result,
-            Err(err) => return Err(state.set_error(err.into())),
-        };
-
-        Ok(result)
+        bcrypt::hash(&password, cost)
+            .map_err(|err| state.set_error(err.into()))
     }))
 }
 
 pub fn bcrypt_verify(lua: &mut hlua::Lua, state: State) {
     lua.set("bcrypt_verify", hlua::function2(move |password: String, hashed: String| -> Result<bool> {
-        let result = match bcrypt::verify(&password, &hashed) {
-            Ok(result) => result,
-            Err(err) => return Err(state.set_error(err.into())),
-        };
-
-        Ok(result)
+        bcrypt::verify(&password, &hashed)
+            .map_err(|err| state.set_error(err.into()))
     }))
 }
 
@@ -129,18 +114,17 @@ pub fn execve(lua: &mut hlua::Lua, state: State) {
 
 pub fn hex(lua: &mut hlua::Lua, state: State) {
     lua.set("hex", hlua::function1(move |bytes: AnyLuaValue| -> Result<String> {
-        let bytes = match byte_array(bytes) {
-            Ok(bytes) => bytes,
-            Err(err) => return Err(state.set_error(err)),
-        };
+        byte_array(bytes)
+            .map_err(|err| state.set_error(err))
+            .map(|bytes| {
+                let mut out = String::new();
 
-        let mut out = String::new();
+                for b in bytes {
+                    out += &format!("{:02x}", b);
+                }
 
-        for b in bytes {
-            out += &format!("{:02x}", b);
-        }
-
-        Ok(out)
+                out
+            })
     }))
 }
 
@@ -206,16 +190,16 @@ pub fn hmac_sha3_512(lua: &mut hlua::Lua, state: State) {
 pub fn html_select(lua: &mut hlua::Lua, state: State) {
     lua.set("html_select", hlua::function2(move |html: String, selector: String| -> Result<AnyLuaValue> {
         html::html_select(&html, &selector)
-            .map(|x| x.into())
             .map_err(|err| state.set_error(err))
+            .map(|x| x.into())
     }))
 }
 
 pub fn html_select_list(lua: &mut hlua::Lua, state: State) {
     lua.set("html_select_list", hlua::function2(move |html: String, selector: String| -> Result<Vec<AnyLuaValue>> {
         html::html_select_list(&html, &selector)
-            .map(|x| x.into_iter().map(|x| x.into()).collect())
             .map_err(|err| state.set_error(err))
+            .map(|x| x.into_iter().map(|x| x.into()).collect())
     }))
 }
 
@@ -223,22 +207,16 @@ pub fn http_basic_auth(lua: &mut hlua::Lua, state: State) {
     lua.set("http_basic_auth", hlua::function3(move |url: String, user: String, password: String| -> Result<bool> {
         let client = reqwest::Client::new();
 
-        let response = match client.get(&url)
-                             .basic_auth(user, Some(password))
-                             .send()
-                             .chain_err(|| "http request failed") {
-            Ok(response) => response,
-            Err(err) => return Err(state.set_error(err)),
-        };
-
-        // println!("{:?}", response);
-        // println!("{:?}", response.headers().get_raw("www-authenticate"));
-        // println!("{:?}", response.status());
-
-        let authorized = response.headers().get_raw("www-authenticate").is_none() &&
-            response.status() != reqwest::StatusCode::Unauthorized;
-
-        Ok(authorized)
+        client.get(&url)
+            .basic_auth(user, Some(password))
+            .send()
+            .chain_err(|| "http request failed")
+            .map_err(|err| state.set_error(err))
+            .map(|response| {
+                debug!("http_basic_auth: {:?}", response);
+                response.headers().get_raw("www-authenticate").is_none() &&
+                    response.status() != reqwest::StatusCode::Unauthorized
+            })
     }))
 }
 
@@ -250,14 +228,12 @@ pub fn http_mksession(lua: &mut hlua::Lua, state: State) {
 
 pub fn http_request(lua: &mut hlua::Lua, state: State) {
     lua.set("http_request", hlua::function4(move |session: String, method: String, url: String, options: AnyLuaValue| -> Result<AnyLuaValue> {
-        let options = match RequestOptions::try_from(options)
-                                .chain_err(|| "invalid request options") {
-            Ok(options) => options,
-            Err(err) => return Err(state.set_error(err)),
-        };
-
-        let req = state.http_request(&session, method, url, options);
-        Ok(req.into())
+        RequestOptions::try_from(options)
+            .chain_err(|| "invalid request options")
+            .map_err(|err| state.set_error(err))
+            .map(|options| {
+                state.http_request(&session, method, url, options).into()
+            })
     }))
 }
 
@@ -270,8 +246,8 @@ pub fn http_send(lua: &mut hlua::Lua, state: State) {
         };
 
         req.send(&state)
-            .map(|resp| resp.into())
             .map_err(|err| state.set_error(err))
+            .map(|resp| resp.into())
     }))
 }
 
@@ -306,15 +282,13 @@ pub fn ldap_bind(lua: &mut hlua::Lua, state: State) {
             Err(err) => return Err(state.set_error(err)),
         };
 
-        let result = match sock.simple_bind(&dn, &password)
-                            .chain_err(|| "fatal error during simple_bind") {
-            Ok(result) => result,
-            Err(err) => return Err(state.set_error(err)),
-        };
-
-        // println!("{:?}", result);
-
-        Ok(result.success().is_ok())
+        sock.simple_bind(&dn, &password)
+            .chain_err(|| "fatal error during simple_bind")
+            .map_err(|err| state.set_error(err))
+            .map(|result| {
+                debug!("ldap_bind: {:?}", result);
+                result.success().is_ok()
+            })
     }))
 }
 
@@ -379,8 +353,8 @@ pub fn ldap_search_bind(lua: &mut hlua::Lua, state: State) {
 pub fn md5(lua: &mut hlua::Lua, state: State) {
     lua.set("md5", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&md5::Md5::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&md5::Md5::digest(&bytes)))
     }))
 }
 
@@ -393,14 +367,10 @@ pub fn mysql_connect(lua: &mut hlua::Lua, state: State) {
                .user(Some(user))
                .pass(Some(password));
 
-        let sock = match mysql::Conn::new(builder) {
-            Ok(sock) => sock,
+        mysql::Conn::new(builder)
             // TODO: setting an error here means we can't bruteforce mysql anymore
-            Err(err) => return Err(state.set_error(err.into())),
-        };
-
-        let id = state.mysql_register(sock);
-        Ok(id)
+            .map_err(|err| state.set_error(err.into()))
+            .map(|sock| state.mysql_register(sock))
     }))
 }
 
@@ -492,40 +462,40 @@ pub fn randombytes(lua: &mut hlua::Lua, _: State) {
 pub fn sha1(lua: &mut hlua::Lua, state: State) {
     lua.set("sha1", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&sha1::Sha1::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&sha1::Sha1::digest(&bytes)))
     }))
 }
 
 pub fn sha2_256(lua: &mut hlua::Lua, state: State) {
     lua.set("sha2_256", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&sha2::Sha256::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&sha2::Sha256::digest(&bytes)))
     }))
 }
 
 pub fn sha2_512(lua: &mut hlua::Lua, state: State) {
     lua.set("sha2_512", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&sha2::Sha512::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&sha2::Sha512::digest(&bytes)))
     }))
 }
 
 pub fn sha3_256(lua: &mut hlua::Lua, state: State) {
     lua.set("sha3_256", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&sha3::Sha3_256::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&sha3::Sha3_256::digest(&bytes)))
     }))
 }
 
 pub fn sha3_512(lua: &mut hlua::Lua, state: State) {
     lua.set("sha3_512", hlua::function1(move |bytes: AnyLuaValue| -> Result<AnyLuaValue> {
         byte_array(bytes)
-            .map(|bytes| lua_bytes(&sha3::Sha3_512::digest(&bytes)))
             .map_err(|err| state.set_error(err))
+            .map(|bytes| lua_bytes(&sha3::Sha3_512::digest(&bytes)))
     }))
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -12,6 +12,7 @@ use digest::{Input, BlockInput, FixedOutput};
 use digest::generic_array::ArrayLength;
 use hmac::{Hmac, Mac};
 use base64;
+use bcrypt;
 
 use reqwest;
 use ldap3;
@@ -73,6 +74,28 @@ pub fn base64_encode(lua: &mut hlua::Lua, state: State) {
         };
 
         Ok(base64::encode(&bytes))
+    }))
+}
+
+pub fn bcrypt(lua: &mut hlua::Lua, state: State) {
+    lua.set("bcrypt", hlua::function2(move |password: String, cost: u32| -> Result<String> {
+        let result = match bcrypt::hash(&password, cost) {
+            Ok(result) => result,
+            Err(err) => return Err(state.set_error(err.into())),
+        };
+
+        Ok(result)
+    }))
+}
+
+pub fn bcrypt_verify(lua: &mut hlua::Lua, state: State) {
+    lua.set("bcrypt_verify", hlua::function2(move |password: String, hashed: String| -> Result<bool> {
+        let result = match bcrypt::verify(&password, &hashed) {
+            Ok(result) => result,
+            Err(err) => return Err(state.set_error(err.into())),
+        };
+
+        Ok(result)
     }))
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -86,6 +86,12 @@ pub fn bcrypt_verify(lua: &mut hlua::Lua, state: State) {
     }))
 }
 
+pub fn clear_err(lua: &mut hlua::Lua, state: State) {
+    lua.set("clear_err", hlua::function0(move || {
+        state.clear_error()
+    }))
+}
+
 pub fn execve(lua: &mut hlua::Lua, state: State) {
     lua.set("execve", hlua::function2(move |prog: String, args: Vec<AnyLuaValue>| -> Result<i32> {
         let args: Vec<_> = args.into_iter()

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -14,6 +14,11 @@ impl LuaMap {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
     pub fn insert<K: Into<String>, V: Into<AnyLuaValue>>(&mut self, k: K, v: V) {
         self.0.insert(AnyHashableLuaValue::LuaString(k.into()), v.into());
     }


### PR DESCRIPTION
This allows connecting to a database, querying a record and testing the password directly with the record in the database. Combined with the large number of cryptographic hash functions it should be possible to use this for a large number of applications.

stuff todo:
- [x] this changes the semantics of `mysql_connect`, a failed mysql_connect login would record an error and get requeued. There should be a way that a failed `mysql_connect` is a failed login attempt (possibly by introducing a function that clears the recorded errors.
- [x] document the new `mysql_connect` and `mysql_query`
- [ ] create a followup issue for scrypt
- [ ] create a followup issue for argon2
- [ ] create a followup issue for postgres
- [ ] create a followup issue for mongodb
- [ ] create a followup issue for redis(?)